### PR TITLE
feat: add ExtensibleSession API, remove ExtensionsMain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-extensions",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   ],
   "homepage": "https://github.com/wexond/electron-extensions#readme",
   "main": "build/index.js",
+  "types": "build/index.d.ts",
   "author": {
     "name": "Eryk Rakowski",
     "email": "sentialx@gmail.com"

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { Session, WebContents, session } from 'electron';
+import { Session, IpcMessageEvent, ipcMain } from 'electron';
 import { resolve, basename } from 'path';
 import { promises, existsSync } from 'fs';
 
@@ -10,8 +10,18 @@ import { runMessagingService } from './services/messaging';
 import { StorageArea } from '../models/storage-area';
 import { startBackgroundPage } from '../utils/extensions';
 
+let id = 1;
+
+const sessions: ExtensibleSession[] = [];
+
+ipcMain.on('get-session-id', (e: IpcMessageEvent) => {
+  e.returnValue = sessions.find(x => x.session === e.sender.session).id;
+});
+
 export class ExtensibleSession {
   public extensions: { [key: string]: Extension } = {};
+
+  public id = id++;
 
   private _initialized = false;
 

--- a/src/main/services/messaging.ts
+++ b/src/main/services/messaging.ts
@@ -223,8 +223,11 @@ export const runMessagingService = (ses: ExtensibleSession) => {
     `send-to-all-extensions-${ses.id}`,
     (e: IpcMessageEvent, msg: string, ...args: any[]) => {
       sendToAllBackgroundPages(ses, msg, ...args);
-      // TODO: UI
-      // appWindow.viewManager.sendToAll(msg, ...args);
+
+      const contents = getWebContentsBySession(ses.session);
+      for (const content of contents) {
+        content.send(msg, ...args);
+      }
     },
   );
 

--- a/src/main/services/messaging.ts
+++ b/src/main/services/messaging.ts
@@ -61,7 +61,7 @@ export const runMessagingService = (ses: ExtensibleSession) => {
   ipcMain.on(
     'api-runtime-reload',
     (e: IpcMessageEvent, extensionId: string) => {
-      const { backgroundPage } = extensions[extensionId];
+      const { backgroundPage } = ses.extensions[extensionId];
 
       if (backgroundPage) {
         const contents = webContents.fromId(e.sender.id);
@@ -73,7 +73,7 @@ export const runMessagingService = (ses: ExtensibleSession) => {
   ipcMain.on(
     'api-runtime-connect',
     async (e: IpcMessageEvent, { extensionId, portId, sender, name }: any) => {
-      const { backgroundPage } = extensions[extensionId];
+      const { backgroundPage } = ses.extensions[extensionId];
       const { webContents } = backgroundPage;
 
       if (e.sender.id !== webContents.id) {
@@ -90,7 +90,7 @@ export const runMessagingService = (ses: ExtensibleSession) => {
     'api-runtime-sendMessage',
     async (e: IpcMessageEvent, data: any) => {
       const { extensionId } = data;
-      const { backgroundPage } = extensions[extensionId];
+      const { backgroundPage } = ses.extensions[extensionId];
       const { webContents } = backgroundPage;
 
       if (e.sender.id !== webContents.id) {
@@ -102,8 +102,8 @@ export const runMessagingService = (ses: ExtensibleSession) => {
   ipcMain.on(
     'api-port-postMessage',
     (e: IpcMessageEvent, { portId, msg }: any) => {
-      Object.keys(extensions).forEach(key => {
-        const { backgroundPage } = extensions[key];
+      Object.keys(ses.extensions).forEach(key => {
+        const { backgroundPage } = ses.extensions[key];
         const contents = backgroundPage.webContents;
 
         if (e.sender.id !== contents.id) {
@@ -111,7 +111,7 @@ export const runMessagingService = (ses: ExtensibleSession) => {
         }
       });
 
-      const contents = getWebContentsBySession(main.session);
+      const contents = getWebContentsBySession(ses.session);
       for (const content of contents) {
         if (content.id !== e.sender.id) {
           content.send(`api-port-postMessage-${portId}`, msg);
@@ -123,7 +123,7 @@ export const runMessagingService = (ses: ExtensibleSession) => {
   ipcMain.on(
     'api-storage-operation',
     (e: IpcMessageEvent, { extensionId, id, area, type, arg }: any) => {
-      const { databases } = main.extensions[extensionId];
+      const { databases } = ses.extensions[extensionId];
 
       const contents = webContents.fromId(e.sender.id);
       const msg = `api-storage-operation-${id}`;
@@ -158,7 +158,7 @@ export const runMessagingService = (ses: ExtensibleSession) => {
     const contents = webContents.fromId(e.sender.id);
 
     if (type === 'create') {
-      const extension = main.extensions[extensionId];
+      const extension = ses.extensions[extensionId];
       const { alarms } = extension;
 
       const { name, alarmInfo } = data;
@@ -216,7 +216,7 @@ export const runMessagingService = (ses: ExtensibleSession) => {
   ipcMain.on(
     'send-to-all-extensions',
     (e: IpcMessageEvent, msg: string, ...args: any[]) => {
-      sendToAllBackgroundPages(main, msg, ...args);
+      sendToAllBackgroundPages(ses, msg, ...args);
       // TODO: UI
       // appWindow.viewManager.sendToAll(msg, ...args);
     },
@@ -225,6 +225,6 @@ export const runMessagingService = (ses: ExtensibleSession) => {
   ipcMain.on('emit-tabs-event', (e: any, name: string, ...data: any[]) => {
     // TODO: UI
     // appWindow.viewManager.sendToAll(`api-emit-event-tabs-${name}`, ...data);
-    sendToAllBackgroundPages(main, `api-emit-event-tabs-${name}`, ...data);
+    sendToAllBackgroundPages(ses, `api-emit-event-tabs-${name}`, ...data);
   });
 };

--- a/src/main/services/messaging.ts
+++ b/src/main/services/messaging.ts
@@ -3,19 +3,19 @@ import {
   getIpcExtension,
   sendToAllBackgroundPages,
 } from '../../utils/extensions';
-import { ExtensionsMain } from '..';
+import { ExtensibleSession } from '..';
 
 const getWebContentsBySession = (ses: Session) => {
   return webContents.getAllWebContents().filter(x => x.session === ses);
 };
 
-export const runMessagingService = (main: ExtensionsMain) => {
+export const runMessagingService = (ses: ExtensibleSession) => {
   ipcMain.on('get-extension', (e: IpcMessageEvent, id: string) => {
-    e.returnValue = getIpcExtension(main.extensions[id]);
+    e.returnValue = getIpcExtension(ses.extensions[id]);
   });
 
   ipcMain.on('get-extensions', (e: IpcMessageEvent) => {
-    const list = { ...main.extensions };
+    const list = { ...ses.extensions };
 
     for (const key in list) {
       list[key] = getIpcExtension(list[key]);
@@ -61,7 +61,7 @@ export const runMessagingService = (main: ExtensionsMain) => {
   ipcMain.on(
     'api-runtime-reload',
     (e: IpcMessageEvent, extensionId: string) => {
-      const { backgroundPage } = main.extensions[extensionId];
+      const { backgroundPage } = extensions[extensionId];
 
       if (backgroundPage) {
         const contents = webContents.fromId(e.sender.id);
@@ -73,7 +73,7 @@ export const runMessagingService = (main: ExtensionsMain) => {
   ipcMain.on(
     'api-runtime-connect',
     async (e: IpcMessageEvent, { extensionId, portId, sender, name }: any) => {
-      const { backgroundPage } = main.extensions[extensionId];
+      const { backgroundPage } = extensions[extensionId];
       const { webContents } = backgroundPage;
 
       if (e.sender.id !== webContents.id) {
@@ -90,7 +90,7 @@ export const runMessagingService = (main: ExtensionsMain) => {
     'api-runtime-sendMessage',
     async (e: IpcMessageEvent, data: any) => {
       const { extensionId } = data;
-      const { backgroundPage } = main.extensions[extensionId];
+      const { backgroundPage } = extensions[extensionId];
       const { webContents } = backgroundPage;
 
       if (e.sender.id !== webContents.id) {
@@ -102,8 +102,8 @@ export const runMessagingService = (main: ExtensionsMain) => {
   ipcMain.on(
     'api-port-postMessage',
     (e: IpcMessageEvent, { portId, msg }: any) => {
-      Object.keys(main.extensions).forEach(key => {
-        const { backgroundPage } = main.extensions[key];
+      Object.keys(extensions).forEach(key => {
+        const { backgroundPage } = extensions[key];
         const contents = backgroundPage.webContents;
 
         if (e.sender.id !== contents.id) {

--- a/src/main/services/protocols.ts
+++ b/src/main/services/protocols.ts
@@ -2,9 +2,9 @@ import { app, protocol } from 'electron';
 import { readFile } from 'fs';
 import { join } from 'path';
 import { parse } from 'url';
-import { ExtensionsMain } from '..';
+import { ExtensibleSession } from '..';
 
-export const registerProtocols = (main: ExtensionsMain) => {
+export const registerProtocols = (ses: ExtensibleSession) => {
   protocol.registerSchemesAsPrivileged([
     {
       scheme: 'electron-extension',
@@ -12,48 +12,43 @@ export const registerProtocols = (main: ExtensionsMain) => {
     },
   ]);
 
-  (app as any).on('session-created', (sess: Electron.session) => {
-    sess.protocol.registerBufferProtocol(
-      'electron-extension',
-      (request, callback) => {
-        const parsed = parse(decodeURIComponent(request.url));
+  ses.session.protocol.registerBufferProtocol(
+    'electron-extension',
+    (request, callback) => {
+      const parsed = parse(decodeURIComponent(request.url));
 
-        if (!parsed.hostname || !parsed.pathname) {
-          return callback();
-        }
+      if (!parsed.hostname || !parsed.pathname) {
+        return callback();
+      }
 
-        const extension = main.extensions[parsed.hostname];
+      const extension = ses.extensions[parsed.hostname];
 
-        if (!extension) {
-          return callback();
-        }
+      if (!extension) {
+        return callback();
+      }
 
-        const { backgroundPage, path } = extension;
+      const { backgroundPage, path } = extension;
 
-        if (
-          backgroundPage &&
-          parsed.pathname === `/${backgroundPage.fileName}`
-        ) {
-          return callback({
-            mimeType: 'text/html',
-            data: backgroundPage.html,
-          });
-        }
-
-        readFile(join(path, parsed.pathname), (err, content) => {
-          if (err) {
-            return (callback as any)(-6); // FILE_NOT_FOUND
-          }
-          return callback(content);
+      if (backgroundPage && parsed.pathname === `/${backgroundPage.fileName}`) {
+        return callback({
+          mimeType: 'text/html',
+          data: backgroundPage.html,
         });
+      }
 
-        return null;
-      },
-      error => {
-        if (error) {
-          console.error(`Failed to register extension protocol: ${error}`);
+      readFile(join(path, parsed.pathname), (err, content) => {
+        if (err) {
+          return (callback as any)(-6); // FILE_NOT_FOUND
         }
-      },
-    );
-  });
+        return callback(content);
+      });
+
+      return null;
+    },
+    error => {
+      if (error) {
+        console.error(`Failed to register extension protocol: ${error}`);
+      }
+    },
+  );
 };

--- a/src/main/services/protocols.ts
+++ b/src/main/services/protocols.ts
@@ -1,17 +1,17 @@
-import { app, protocol } from 'electron';
+import { protocol } from 'electron';
 import { readFile } from 'fs';
 import { join } from 'path';
 import { parse } from 'url';
 import { ExtensibleSession } from '..';
 
-export const registerProtocols = (ses: ExtensibleSession) => {
-  protocol.registerSchemesAsPrivileged([
-    {
-      scheme: 'electron-extension',
-      privileges: { bypassCSP: true, secure: true },
-    },
-  ]);
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: 'electron-extension',
+    privileges: { bypassCSP: true, secure: true },
+  },
+]);
 
+export const registerProtocols = (ses: ExtensibleSession) => {
   ses.session.protocol.registerBufferProtocol(
     'electron-extension',
     (request, callback) => {

--- a/src/main/services/web-request.ts
+++ b/src/main/services/web-request.ts
@@ -1,4 +1,4 @@
-import { ipcMain, Session, WebContents, webContents } from 'electron';
+import { ipcMain, WebContents, webContents } from 'electron';
 import enhanceWebRequest from 'electron-better-web-request';
 import { makeId } from '../../utils/string';
 import { ExtensibleSession } from '..';

--- a/src/main/services/web-request.ts
+++ b/src/main/services/web-request.ts
@@ -1,6 +1,7 @@
 import { ipcMain, Session, WebContents, webContents } from 'electron';
 import enhanceWebRequest from 'electron-better-web-request';
 import { makeId } from '../../utils/string';
+import { ExtensibleSession } from '..';
 
 const eventListeners: { [key: string]: Function } = {};
 
@@ -142,8 +143,8 @@ const resolver = (listeners: any) => {
   return response;
 };
 
-export const runWebRequestService = (ses: Session) => {
-  const { webRequest } = enhanceWebRequest(ses);
+export const runWebRequestService = (ses: ExtensibleSession) => {
+  const { webRequest } = enhanceWebRequest(ses.session);
 
   // Handle listener add and remove.
 

--- a/src/renderer/api/browser-action.ts
+++ b/src/renderer/api/browser-action.ts
@@ -3,7 +3,10 @@ import { ipcRenderer } from 'electron';
 import { IpcExtension } from '../../models/ipc-extension';
 import { IpcEvent } from './events/ipc-event';
 
-export const getBrowserAction = (extension: IpcExtension) => ({
+export const getBrowserAction = (
+  extension: IpcExtension,
+  sessionId: number,
+) => ({
   onClicked: new IpcEvent('browserAction', 'onClicked'),
 
   setIcon: (details: chrome.browserAction.TabIconDetails, cb: any) => {
@@ -18,7 +21,11 @@ export const getBrowserAction = (extension: IpcExtension) => ({
   },
 
   setBadgeText: (details: chrome.browserAction.BadgeTextDetails, cb: any) => {
-    ipcRenderer.send('api-browserAction-setBadgeText', extension.id, details);
+    ipcRenderer.send(
+      `api-browserAction-setBadgeText-${sessionId}`,
+      extension.id,
+      details,
+    );
 
     if (cb) {
       ipcRenderer.once('api-browserAction-setBadgeText', () => {

--- a/src/renderer/api/index.ts
+++ b/src/renderer/api/index.ts
@@ -10,13 +10,13 @@ import { getBrowserAction } from './browser-action';
 import { getWebRequest } from './web-request';
 import { getWebNavigation } from './web-navigation';
 
-export const getAPI = (extension: IpcExtension) => {
+export const getAPI = (extension: IpcExtension, sessionId: number) => {
   const api = {
-    runtime: getRuntime(extension),
-    storage: getStorage(extension.id),
-    tabs: getTabs(extension),
+    runtime: getRuntime(extension, sessionId),
+    storage: getStorage(extension.id, sessionId),
+    tabs: getTabs(extension, sessionId),
     i18n: getI18n(extension),
-    browserAction: getBrowserAction(extension),
+    browserAction: getBrowserAction(extension, sessionId),
     webRequest: getWebRequest(),
     webNavigation: getWebNavigation(),
 

--- a/src/renderer/api/runtime.ts
+++ b/src/renderer/api/runtime.ts
@@ -13,7 +13,7 @@ const getSender = (id: string): chrome.runtime.MessageSender => ({
   tab: { id: remote.getCurrentWebContents().id } as any,
 });
 
-export const getRuntime = (extension: IpcExtension) => ({
+export const getRuntime = (extension: IpcExtension, sessionId: number) => ({
   lastError: null as any,
   id: extension.id,
   onConnect: new LocalEvent(),
@@ -58,7 +58,7 @@ export const getRuntime = (extension: IpcExtension) => ({
       );
     }
 
-    ipcRenderer.send('api-runtime-sendMessage', {
+    ipcRenderer.send(`api-runtime-sendMessage-${sessionId}`, {
       extensionId,
       portId,
       sender,
@@ -89,7 +89,7 @@ export const getRuntime = (extension: IpcExtension) => ({
       name = args[0].name;
     }
 
-    ipcRenderer.send('api-runtime-connect', {
+    ipcRenderer.send(`api-runtime-connect-${sessionId}`, {
       extensionId,
       portId,
       sender,
@@ -100,7 +100,7 @@ export const getRuntime = (extension: IpcExtension) => ({
   },
 
   reload: () => {
-    ipcRenderer.send('api-runtime-reload', extension.id);
+    ipcRenderer.send(`api-runtime-reload-${sessionId}`, extension.id);
   },
 
   getURL: (path: string) =>

--- a/src/renderer/api/storage.ts
+++ b/src/renderer/api/storage.ts
@@ -8,9 +8,10 @@ const sendStorageOperation = (
   area: string,
   type: string,
   callback: any,
+  sessionId: number,
 ) => {
   const id = makeId(32);
-  ipcRenderer.send('api-storage-operation', {
+  ipcRenderer.send(`api-storage-operation-${sessionId}`, {
     extensionId,
     id,
     arg,
@@ -28,16 +29,18 @@ const sendStorageOperation = (
   }
 };
 
-const getStorageArea = (id: string, area: string) => ({
-  set: (arg: any, cb: any) => sendStorageOperation(id, arg, area, 'set', cb),
-  get: (arg: any, cb: any) => sendStorageOperation(id, arg, area, 'get', cb),
+const getStorageArea = (id: string, area: string, sessionId: number) => ({
+  set: (arg: any, cb: any) =>
+    sendStorageOperation(id, arg, area, 'set', cb, sessionId),
+  get: (arg: any, cb: any) =>
+    sendStorageOperation(id, arg, area, 'get', cb, sessionId),
   remove: (arg: any, cb: any) =>
-    sendStorageOperation(id, arg, area, 'remove', cb),
+    sendStorageOperation(id, arg, area, 'remove', cb, sessionId),
   clear: (arg: any, cb: any) =>
-    sendStorageOperation(id, arg, area, 'clear', cb),
+    sendStorageOperation(id, arg, area, 'clear', cb, sessionId),
 });
 
-export const getStorage = (extensionId: string) => ({
-  local: getStorageArea(extensionId, 'local'),
-  managed: getStorageArea(extensionId, 'managed'),
+export const getStorage = (extensionId: string, sessionId: number) => ({
+  local: getStorageArea(extensionId, 'local', sessionId),
+  managed: getStorageArea(extensionId, 'managed', sessionId),
 });

--- a/src/renderer/api/tabs.ts
+++ b/src/renderer/api/tabs.ts
@@ -6,7 +6,7 @@ import { IpcEvent } from './events/ipc-event';
 import { makeId } from '../../utils/string';
 import { IpcExtension } from '../../models/ipc-extension';
 
-export const getTabs = (extension: IpcExtension) => {
+export const getTabs = (extension: IpcExtension, sessionId: number) => {
   const tabs = {
     onCreated: new IpcEvent('tabs', 'onCreated'),
     onUpdated: new IpcEvent('tabs', 'onUpdated'),
@@ -29,7 +29,7 @@ export const getTabs = (extension: IpcExtension) => {
       queryInfo: chrome.tabs.QueryInfo,
       callback: (tabs: chrome.tabs.Tab[]) => void,
     ) => {
-      ipcRenderer.send('api-tabs-query');
+      ipcRenderer.send(`api-tabs-query-${sessionId}`);
 
       ipcRenderer.once(
         'api-tabs-query',
@@ -62,7 +62,7 @@ export const getTabs = (extension: IpcExtension) => {
       createProperties: chrome.tabs.CreateProperties,
       callback: (tab: chrome.tabs.Tab) => void = null,
     ) => {
-      ipcRenderer.send('api-tabs-create', createProperties);
+      ipcRenderer.send(`api-tabs-create-${sessionId}`, createProperties);
 
       if (callback) {
         ipcRenderer.once(
@@ -83,7 +83,7 @@ export const getTabs = (extension: IpcExtension) => {
           );
         }
 
-        ipcRenderer.send('api-tabs-insertCSS', tabId, details);
+        ipcRenderer.send(`api-tabs-insertCSS-${sessionId}`, tabId, details);
 
         ipcRenderer.once('api-tabs-insertCSS', () => {
           if (callback) {
@@ -111,7 +111,7 @@ export const getTabs = (extension: IpcExtension) => {
         }
 
         const responseId = makeId(32);
-        ipcRenderer.send('api-tabs-executeScript', {
+        ipcRenderer.send(`api-tabs-executeScript-${sessionId}`, {
           tabId,
           details,
           responseId,
@@ -140,7 +140,7 @@ export const getTabs = (extension: IpcExtension) => {
     },
 
     setZoom: (tabId: number, zoomFactor: number, callback: () => void) => {
-      ipcRenderer.send('api-tabs-setZoom', tabId, zoomFactor);
+      ipcRenderer.send(`api-tabs-setZoom-${sessionId}`, tabId, zoomFactor);
 
       ipcRenderer.once('api-tabs-setZoom', () => {
         if (callback) {
@@ -150,7 +150,7 @@ export const getTabs = (extension: IpcExtension) => {
     },
 
     getZoom: (tabId: number, callback: (zoomFactor: number) => void) => {
-      ipcRenderer.send('api-tabs-getZoom', tabId);
+      ipcRenderer.send(`api-tabs-getZoom-${sessionId}`, tabId);
 
       ipcRenderer.once(
         'api-tabs-getZoom',
@@ -163,7 +163,7 @@ export const getTabs = (extension: IpcExtension) => {
     },
 
     detectLanguage: (tabId: number, callback: (language: string) => void) => {
-      ipcRenderer.send('api-tabs-detectLanguage', tabId);
+      ipcRenderer.send(`api-tabs-detectLanguage-${sessionId}`, tabId);
 
       ipcRenderer.once(
         'api-tabs-detectLanguage',

--- a/src/renderer/background/index.ts
+++ b/src/renderer/background/index.ts
@@ -18,13 +18,15 @@ ipcRenderer.setMaxListeners(0);
 
 const extensionId = parse(window.location.href).hostname;
 
+const sessionId: number = ipcRenderer.sendSync('get-session-id');
+
 const extension: IpcExtension = ipcRenderer.sendSync(
-  'get-extension',
+  `get-extension-${sessionId}`,
   extensionId,
 );
 
 process.once('loaded', () => {
-  const api = getAPI(extension);
+  const api = getAPI(extension, sessionId);
 
   window.chrome = api;
   window.browser = api;

--- a/src/renderer/content/index.ts
+++ b/src/renderer/content/index.ts
@@ -6,8 +6,10 @@ import { IpcExtension } from '../../models/ipc-extension';
 import { getIsolatedWorldId } from '../../utils/isolated-worlds';
 import { injectContentScript, injectChromeApi } from './inject';
 
+const sessionId: number = ipcRenderer.sendSync('get-session-id');
+
 const extensions: { [key: string]: IpcExtension } = ipcRenderer.sendSync(
-  'get-extensions',
+  `get-extensions-${sessionId}`,
 );
 
 webFrame.executeJavaScript('window', false, w => {
@@ -34,7 +36,7 @@ ipcRenderer.on(
     webContentsId: number,
   ) => {
     const worldId = getIsolatedWorldId(extensionId);
-    injectChromeApi(extensions[extensionId], worldId);
+    injectChromeApi(extensions[extensionId], worldId, sessionId);
 
     webFrame.executeJavaScriptInIsolatedWorld(
       worldId,
@@ -77,7 +79,7 @@ process.once('loaded', () => {
             runAt: script.run_at || 'document_idle',
           };
 
-          injectContentScript(newScript, extension);
+          injectContentScript(newScript, extension, sessionId);
         });
       } catch (readError) {
         console.error('Failed to read content scripts', readError);

--- a/src/renderer/content/inject.ts
+++ b/src/renderer/content/inject.ts
@@ -12,9 +12,10 @@ const runContentScript = (
   code: string,
   extension: IpcExtension,
   worldId: number,
+  sessionId: number,
 ) => {
   const parsed = parse(url);
-  injectChromeApi(extension, worldId);
+  injectChromeApi(extension, worldId, sessionId);
 
   webFrame.executeJavaScriptInIsolatedWorld(worldId, [
     {
@@ -45,7 +46,11 @@ const runStylesheet = (url: string, code: string) => {
   return compiledWrapper.call(window, code);
 };
 
-export const injectContentScript = (script: any, extension: IpcExtension) => {
+export const injectContentScript = (
+  script: any,
+  extension: IpcExtension,
+  sessionId: number,
+) => {
   if (
     !script.matches.some((x: string) =>
       matchesPattern(
@@ -67,6 +72,7 @@ export const injectContentScript = (script: any, extension: IpcExtension) => {
         js.code,
         extension,
         getIsolatedWorldId(extension.id),
+        sessionId,
       );
 
       if (script.runAt === 'document_start') {
@@ -93,8 +99,12 @@ export const injectContentScript = (script: any, extension: IpcExtension) => {
   }
 };
 
-export const injectChromeApi = (extension: IpcExtension, worldId: number) => {
-  const context = getAPI(extension);
+export const injectChromeApi = (
+  extension: IpcExtension,
+  worldId: number,
+  sessionId: number,
+) => {
+  const context = getAPI(extension, sessionId);
 
   webFrame.setIsolatedWorldHumanReadableName(worldId, name);
   webFrame.executeJavaScriptInIsolatedWorld(

--- a/src/utils/extensions.ts
+++ b/src/utils/extensions.ts
@@ -4,7 +4,7 @@ import { resolve } from 'path';
 import { format } from 'url';
 import { Extension } from '../models/extension';
 import { IpcExtension } from '../models/ipc-extension';
-import { ExtensionsMain } from '../main';
+import { ExtensibleSession } from '../main';
 
 export const getIpcExtension = (extension: Extension): IpcExtension => {
   const ipcExtension: Extension = { ...extension };
@@ -45,7 +45,7 @@ export const startBackgroundPage = async (
     }
 
     const contents: WebContents = (webContents as any).create({
-      partition: 'persist:wexond_extension',
+      partition: 'persist:electron-extension',
       isBackgroundPage: true,
       preload: resolve(__dirname, '../..', 'renderer/background/index.js'),
       commandLineSwitches: ['--background-page'],
@@ -77,12 +77,12 @@ export const startBackgroundPage = async (
 };
 
 export const sendToAllBackgroundPages = (
-  main: ExtensionsMain,
+  ses: ExtensibleSession,
   msg: string,
   ...args: any[]
 ) => {
-  for (const key in main.extensions) {
-    const { webContents } = main.extensions[key].backgroundPage;
+  for (const key in ses.extensions) {
+    const { webContents } = ses.extensions[key].backgroundPage;
     webContents.send(msg, ...args);
   }
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,9 +7,10 @@
     "noImplicitThis": true,
     "alwaysStrict": true,
 
+    "declaration": true,
+
     "module": "commonjs",
     "target": "es6",
-    "allowJs": true,
     "sourceMap": true,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
This could allow users to load different extensions to different sessions.

Usage:
```typescript
import { app, session } from 'electron';

app.once('ready', () => {
  const extensions = new ExtensibleSession(session.defaultSession);
  extensions.loadExtension('path');
});
```